### PR TITLE
Log imports

### DIFF
--- a/requre/__init__.py
+++ b/requre/__init__.py
@@ -1,3 +1,8 @@
-from requre.import_system import decorate, replace, replace_module
+from requre.import_system import decorate, replace, replace_module, log_imports
 
-__all__ = [decorate.__name__, replace.__name__, replace_module.__name__]
+__all__ = [
+    decorate.__name__,
+    replace.__name__,
+    replace_module.__name__,
+    log_imports.__name__,
+]

--- a/requre/import_system.py
+++ b/requre/import_system.py
@@ -129,6 +129,22 @@ def replace(
     return upgraded_import_system
 
 
+def log_imports(
+    what: str, who_name: Union[str, List[str]] = None, debug_file: Optional[str] = None
+) -> "UpgradeImportSystem":
+    """
+    Log the imports.
+
+    :param what: which module(s) is(/are) affected
+    :param who_name: where is the import logged
+    :param debug_file: file where to store debug information about replacements
+    :return: UpgradeImportSystem
+    """
+    upgraded_import_system = UpgradeImportSystem(debug_file=debug_file)
+    upgraded_import_system.log_imports(what=what, who_name=who_name)
+    return upgraded_import_system
+
+
 class UpgradeImportSystem:
     def __init__(self, debug_file: Optional[str] = None) -> None:
         self.filters: List[Tuple] = []
@@ -237,6 +253,25 @@ class UpgradeImportSystem:
             self.upgrade(
                 (where, {"who_name": who}, {what: [ReplaceType.REPLACE, replacement]})
             )
+        return self
+
+    def log_imports(
+        self, what: str, who_name: Union[str, List[str]] = None
+    ) -> "UpgradeImportSystem":
+        """
+        Log the imports.
+
+        :param what: which module(s) is(/are) affected
+        :param who_name: where is the import logged
+        :return: self (chaining is supported)
+        """
+        if not who_name:
+            self.upgrade((what, {}))
+            return self
+
+        who_name = who_name if isinstance(who_name, list) else [who_name]
+        for who in who_name:
+            self.upgrade((what, {"who_name": who}))
         return self
 
     def upgrade(self, *filters):


### PR DESCRIPTION
- Add function/method for logging imports.


Usage in ogr:

```python
ogr_import_system = (
    upgrade_import_system(debug_file="modules.out")
    .log_imports(what="^requests$", who_name=["ogr", "github", "gitlab"])
    .decorate(
        where="^requests$",
        what="Session.send",
        who_name=[
            "ogr.services.pagure",
            "gitlab",
            "github.MainClass",
            "github.Requester",
            "ogr.services.github_tweak",
        ],
        decorator=RequestResponseHandling.decorator(item_list=[]),
    )
)
```