### PR TITLE
Improve import speed

### DIFF
--- a/requre/import_system.py
+++ b/requre/import_system.py
@@ -23,14 +23,13 @@
 
 import builtins
 import functools
-import inspect
 import re
 from enum import Enum
 from importlib import reload
 from types import ModuleType
 from typing import Optional, Dict, Any, Callable, List, Tuple, Union
 
-from requre.utils import Replacement
+from requre.utils import Replacement, get_module_of_previous_context
 
 
 class ReplaceType(Enum):
@@ -297,7 +296,7 @@ class UpgradeImportSystem:
             one_filter = filter_item[0]
             additional_filters = filter_item[1]
             if re.search(one_filter, name):
-                mod = inspect.getmodule(inspect.stack()[1][0])
+                mod = get_module_of_previous_context()
                 fromlist = ()
                 if len(args) > 3:
                     fromlist = list(args)[3]

--- a/requre/utils.py
+++ b/requre/utils.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import inspect
 import logging
 import shlex
 import subprocess
@@ -141,3 +141,10 @@ class DictProcessing:
         if isinstance(obj, list):
             for item in obj:
                 DictProcessing.replace(obj=item, key=key, value=value)
+
+
+def get_module_of_previous_context():
+    current_ctx = inspect.currentframe().f_back.f_back
+    frameinfo_args = (current_ctx,) + inspect.getframeinfo(current_ctx, 1)
+    frameinfo = inspect.FrameInfo(*frameinfo_args)
+    return inspect.getmodule(frameinfo[0])


### PR DESCRIPTION
- Optimize the import system.

##### Context:

```python
def getouterframes(frame, context=1):
    """Get a list of records for a frame and all higher (calling) frames.

    Each record contains a frame object, filename, line number, function
    name, a list of lines of context, and index within the context."""
    framelist = []
    while frame:
        frameinfo = (frame,) + getframeinfo(frame, context)
        framelist.append(FrameInfo(*frameinfo))
        frame = frame.f_back
    return framelist

def stack(context=1):
    """Return a list of records for the stack above the caller's frame."""
    return getouterframes(sys._getframe(1), context)
```

- We are getting the second item of the `stack` but need to generate whole list in the `getouterframes`.
- => Proposed solution directly generate the second object.