### PR TITLE
Read write mode

### DIFF
--- a/requre/helpers/files.py
+++ b/requre/helpers/files.py
@@ -67,7 +67,7 @@ class StoreFiles:
                     ) as tar_store:
                         tar_store.add(name=artifact_name)
                     fileobj.seek(0)
-                    metadata = {DataMiner.LATENCY_KEY: 0}
+                    metadata = {DataMiner().LATENCY_KEY: 0}
                     pers_storage.store(
                         keys=cls.basic_ps_keys + keys,
                         values=fileobj.read(),

--- a/requre/objects.py
+++ b/requre/objects.py
@@ -79,18 +79,18 @@ class ObjectStorage:
             object_storage.persistent_storage.mode == StorageMode.write
             or (
                 object_storage.persistent_storage.mode == StorageMode.read_write
-                and DataMiner.data_type == DataTypes.Dict
+                and DataMiner().data_type == DataTypes.Dict
                 and object_storage.store_keys not in object_storage.persistent_storage
             )
             or (
                 object_storage.persistent_storage.mode == StorageMode.read_write
-                and DataMiner.data_type in [DataTypes.DictWithList, DataTypes.List]
+                and DataMiner().data_type in [DataTypes.DictWithList, DataTypes.List]
             )
         ):
             time_before = original_time()
             response = func(*args, **kwargs)
             time_after = original_time()
-            metadata = {DataMiner.LATENCY_KEY: time_after - time_before}
+            metadata = {DataMiner().LATENCY_KEY: time_after - time_before}
 
             object_storage.write(response, metadata)
             logger.debug(f"WRITE Keys: {keys} -> {response}")

--- a/requre/objects.py
+++ b/requre/objects.py
@@ -26,8 +26,9 @@ import logging
 import pickle
 from typing import Optional, Callable, Any, List, Dict
 
-from requre.storage import PersistentObjectStorage, DataMiner, original_time, DataTypes
-from requre.utils import StorageMode
+from requre.storage import PersistentObjectStorage, DataMiner, original_time
+
+logger = logging.getLogger(__name__)
 
 
 class ObjectStorage:
@@ -67,26 +68,10 @@ class ObjectStorage:
         :param kwargs: parameters of original function
         :return: output of called func
         """
-        logger = logging.getLogger(cls.__name__)
+
         object_storage = cls(store_keys=keys)
 
-        if object_storage.store_keys in object_storage.persistent_storage:
-            logger.debug(
-                f"{object_storage.store_keys} found in the persistent storage."
-            )
-
-        if (
-            object_storage.persistent_storage.mode == StorageMode.write
-            or (
-                object_storage.persistent_storage.mode == StorageMode.read_write
-                and DataMiner().data_type == DataTypes.Dict
-                and object_storage.store_keys not in object_storage.persistent_storage
-            )
-            or (
-                object_storage.persistent_storage.mode == StorageMode.read_write
-                and DataMiner().data_type in [DataTypes.DictWithList, DataTypes.List]
-            )
-        ):
+        if object_storage.persistent_storage.do_store(keys):
             time_before = original_time()
             response = func(*args, **kwargs)
             time_after = original_time()

--- a/requre/objects.py
+++ b/requre/objects.py
@@ -84,13 +84,14 @@ class ObjectStorage:
             )
             or (
                 object_storage.persistent_storage.mode == StorageMode.read_write
-                and DataTypes.DictWithList
+                and DataMiner.data_type in [DataTypes.DictWithList, DataTypes.List]
             )
         ):
             time_before = original_time()
             response = func(*args, **kwargs)
             time_after = original_time()
             metadata = {DataMiner.LATENCY_KEY: time_after - time_before}
+
             object_storage.write(response, metadata)
             logger.debug(f"WRITE Keys: {keys} -> {response}")
             return response

--- a/requre/requre_patch.py
+++ b/requre/requre_patch.py
@@ -11,8 +11,8 @@ import yaml
 import builtins
 
 from requre.import_system import upgrade_import_system, UpgradeImportSystem
-from requre.utils import STORAGE, DictProcessing
-from requre.storage import DataMiner
+from requre.utils import DictProcessing
+from requre.storage import DataMiner, PersistentObjectStorage
 from requre.constants import (
     ENV_REPLACEMENT_FILE,
     ENV_STORAGE_FILE,
@@ -98,7 +98,7 @@ def apply_fn():
         if if_latency:
             debug_print("Use latency for function calls")
             DataMiner().use_latency = True
-        STORAGE.storage_file = storage_file
+        PersistentObjectStorage().storage_file = storage_file
         spec = importlib.util.spec_from_file_location("replacements", replacement_file)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
@@ -122,7 +122,7 @@ def apply_fn():
                 f"in {replacement_file} there is not defined '{replacement_var}' variable",
             )
         # register dump command, when python finish
-        atexit.register(STORAGE.dump)
+        atexit.register(PersistentObjectStorage().dump)
 
 
 def get_current_python_version():

--- a/requre/storage.py
+++ b/requre/storage.py
@@ -188,13 +188,14 @@ class DataMiner(metaclass=SingletonMeta):
     compatibility with requre storage version files
     """
 
-    current_time = original_time()
-    data: DataStructure
-    data_type: DataTypes = DataTypes.List
-    use_latency = False
-    LATENCY_KEY = "latency"
-    key: str = "all"
-    key_stategy_cls = StorageKeysInspectDefault
+    def __init__(self):
+        self.current_time = original_time()
+        self.data: Optional[DataStructure] = None
+        self.data_type: DataTypes = DataTypes.List
+        self.use_latency = False
+        self.LATENCY_KEY = "latency"
+        self.key: str = "all"
+        self.key_stategy_cls = StorageKeysInspectDefault
 
     def get_latency(self, regenerate=True) -> float:
         """

--- a/requre/storage.py
+++ b/requre/storage.py
@@ -401,7 +401,7 @@ class PersistentObjectStorage(metaclass=SingletonMeta):
         if self.dump_after_store:
             self.dump()
 
-    def _read(self, keys: List) -> Any:
+    def read(self, keys: List) -> Any:
         """
         Reads data from dictionary object structure based on keys.
         If keys does not exists
@@ -436,7 +436,7 @@ class PersistentObjectStorage(metaclass=SingletonMeta):
         return True
 
     def __getitem__(self, key):
-        return self._read(keys=key)
+        return self.read(keys=key)
 
     def __setitem__(self, key, value):
         self.store(keys=key, values=value, metadata={})

--- a/requre/storage.py
+++ b/requre/storage.py
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import inspect
 import os
 import time
 from _collections_abc import Hashable
 from enum import Enum
 from typing import Dict, List, Any, Optional, Callable
-import inspect
 
 import yaml
 
@@ -431,8 +431,8 @@ class PersistentObjectStorage(metaclass=SingletonMeta):
             if item not in current_level:
                 return False
             current_level = current_level[item]
-        if DataMiner.data_type in [DataTypes.Dict, DataTypes.DictWithList]:
-            return DataMiner.key in current_level
+        if DataMiner().data_type in [DataTypes.Dict, DataTypes.DictWithList]:
+            return DataMiner().key in current_level
         return True
 
     def __getitem__(self, key):
@@ -453,8 +453,8 @@ class PersistentObjectStorage(metaclass=SingletonMeta):
             last_level = current_level
             current_level = current_level[item]
 
-        if DataMiner.data_type == DataTypes.Dict:
-            del current_level[DataMiner.key]
+        if DataMiner().data_type == DataTypes.Dict:
+            del current_level[DataMiner().key]
         else:
             del last_level[key[-1]]
 

--- a/requre/utils.py
+++ b/requre/utils.py
@@ -23,22 +23,19 @@ import inspect
 import logging
 import shlex
 import subprocess
+from enum import Enum
 from pathlib import Path
 from typing import Union, Any
 
 from requre.exceptions import PersistentStorageException
-from requre.storage import PersistentObjectStorage
 
 logger = logging.getLogger(__name__)
 
-STORAGE = PersistentObjectStorage()
 
-
-def get_if_recording() -> bool:
-    """
-    True if storage file is set, means that it is requested to use storage.
-    """
-    return bool(STORAGE.storage_file)
+class StorageMode(Enum):
+    read = 0
+    write = 1
+    read_write = 2
 
 
 def run_command(cmd, error_message=None, cwd=None, fail=True, output=False):

--- a/requre/utils.py
+++ b/requre/utils.py
@@ -33,9 +33,10 @@ logger = logging.getLogger(__name__)
 
 
 class StorageMode(Enum):
-    read = 0
-    write = 1
-    read_write = 2
+    default = 0
+    read = 1
+    write = 2
+    append = 3
 
 
 def run_command(cmd, error_message=None, cwd=None, fail=True, output=False):

--- a/tests/test_e2e_test_patching.py
+++ b/tests/test_e2e_test_patching.py
@@ -23,7 +23,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 def is_sudo_possible():
     random_file = "/usr/bin/test_superuser"
     try:
-        run_command(f"sudo touch {random_file}")
+        run_command(f"sudo -n touch {random_file}")
     except PersistentStorageException:
         return False
     run_command(f"sudo rm {random_file}")

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -190,7 +190,7 @@ class SessionRecordingWithFileStore(Base):
 
 class DynamicFileStorage(Base):
     @StoreFiles.guess_args
-    def create_file(self, value, target_file):
+    def write_to_file(self, value, target_file):
         with open(target_file, "w") as fd:
             fd.write(value)
 
@@ -199,13 +199,13 @@ class DynamicFileStorage(Base):
         File storage where it try to guess what to store, based on *args and **kwargs values
         """
         self.create_temp_file()
-        self.create_file("ahoj", self.temp_file)
-        self.create_file("cao", self.temp_file)
+        self.write_to_file("ahoj", self.temp_file)
+        self.write_to_file("cao", self.temp_file)
 
         PersistentObjectStorage().dump()
         PersistentObjectStorage().mode = StorageMode.read
         self.create_temp_file()
-        self.create_file("first", self.temp_file)
+        self.write_to_file("ahoj", self.temp_file)
         with open(self.temp_file, "r") as fd:
             content = fd.read()
             self.assertIn("ahoj", content)
@@ -213,7 +213,7 @@ class DynamicFileStorage(Base):
         # mix with positional option
 
         self.create_temp_file()
-        self.create_file("second", self.temp_file)
+        self.write_to_file("cao", self.temp_file)
         with open(self.temp_file, "r") as fd:
             content = fd.read()
             self.assertNotIn("ahoj", content)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,12 +1,13 @@
 import os
+import tarfile
 import tempfile
+from io import BytesIO
 
 from requre.helpers.files import StoreFiles
 from requre.storage import PersistentObjectStorage
-from tests.testbase import BaseClass
-import tarfile
-from io import BytesIO
+from requre.utils import StorageMode
 from tests.test_function_output import StoreFunctionOutput
+from tests.testbase import BaseClass
 
 
 class Base(BaseClass):
@@ -51,7 +52,7 @@ class FileStorage(Base):
         self.create_file_content("cao", target_file=self.temp_file)
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         self.create_file_content("first", target_file=self.temp_file)
         with open(self.temp_file, "r") as fd:
@@ -77,7 +78,7 @@ class FileStorage(Base):
         self.create_file_content("cao", self.temp_file)
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         self.create_temp_file()
         self.create_file_content("first", self.temp_file)
@@ -112,7 +113,7 @@ class FileStorage(Base):
             self.assertIn("ciao", content)
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         self.create_temp_dir()
         self.create_dir_content(
@@ -136,7 +137,7 @@ class FileStorage(Base):
         )
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         self.create_temp_dir()
         self.create_dir_content(
@@ -168,7 +169,7 @@ class SessionRecordingWithFileStore(Base):
         self.create_file_content("cao", target_file=self.temp_file)
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         before = str(PersistentObjectStorage().storage_object)
 
@@ -202,7 +203,7 @@ class DynamicFileStorage(Base):
         self.create_file("cao", self.temp_file)
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         self.create_temp_file()
         self.create_file("first", self.temp_file)
         with open(self.temp_file, "r") as fd:
@@ -239,7 +240,7 @@ class StoreOutputFile(Base):
         ofile2 = self.create_file("cao")
 
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         oofile1 = self.create_file("first")
         with open(ofile1, "r") as fd:

--- a/tests/test_function_output.py
+++ b/tests/test_function_output.py
@@ -2,7 +2,7 @@ import tempfile
 
 from requre.helpers.simple_object import Simple
 from requre.storage import PersistentObjectStorage
-from requre.utils import run_command
+from requre.utils import run_command, StorageMode
 from tests.testbase import BaseClass
 
 
@@ -22,7 +22,7 @@ class StoreFunctionOutput(BaseClass):
         output = self.run_command_wrapper(cmd=["true"])
         self.assertTrue(output)
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         before = str(PersistentObjectStorage().storage_object)
         output = self.run_command_wrapper(cmd=["true"])
         after = str(PersistentObjectStorage().storage_object)
@@ -41,16 +41,16 @@ class StoreFunctionOutput(BaseClass):
         output = self.run_command_wrapper(cmd=["cat", self.file_name], output=True)
         self.assertIn("ahoj", output)
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         with open(self.file_name, "a") as fd:
             fd.write("cao\n")
         output = self.run_command_wrapper(cmd=["cat", self.file_name], output=True)
         self.assertIn("ahoj", output)
         self.assertNotIn("cao", output)
-        PersistentObjectStorage()._is_write_mode = True
+        PersistentObjectStorage().mode = StorageMode.write
         output = self.run_command_wrapper(cmd=["cat", self.file_name], output=True)
         self.assertIn("cao", output)
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         output = self.run_command_wrapper(cmd=["cat", self.file_name], output=True)
         self.assertIn("cao", output)

--- a/tests/test_import_system.py
+++ b/tests/test_import_system.py
@@ -6,7 +6,7 @@ import unittest
 from requre import decorate, replace, replace_module
 from requre.helpers.tempfile import TempFile
 from requre.import_system import ReplaceType, upgrade_import_system, UpgradeImportSystem
-from requre.utils import STORAGE
+from requre.storage import PersistentObjectStorage
 
 SELECTOR = str(os.path.basename(__file__).rsplit(".", 1)[0])
 
@@ -261,10 +261,12 @@ class TestUpgradeImportSystem(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         tmpdir = tempfile.mkdtemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpfile
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+            tmpfile,
         )
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpdir
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+            tmpdir,
         )
         self.assertFalse(os.path.exists(tmpfile))
         self.assertTrue(os.path.exists(tmpdir))
@@ -286,10 +288,12 @@ class TestUpgradeImportSystem(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         tmpdir = tempfile.mkdtemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpfile
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+            tmpfile,
         )
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpdir
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+            tmpdir,
         )
         self.assertFalse(os.path.exists(tmpfile))
         self.assertTrue(os.path.exists(tmpdir))
@@ -310,10 +314,12 @@ class TestUpgradeImportSystem(unittest.TestCase):
             tmpfile = tempfile.mktemp()
             tmpdir = tempfile.mkdtemp()
             self.assertIn(
-                f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpfile
+                f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+                tmpfile,
             )
             self.assertIn(
-                f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpdir
+                f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+                tmpdir,
             )
             self.assertFalse(os.path.exists(tmpfile))
             self.assertTrue(os.path.exists(tmpdir))
@@ -332,10 +338,12 @@ class TestUpgradeImportSystem(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         tmpdir = tempfile.mkdtemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpfile
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+            tmpfile,
         )
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpdir
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+            tmpdir,
         )
         self.assertFalse(os.path.exists(tmpfile))
         self.assertTrue(os.path.exists(tmpdir))
@@ -356,10 +364,12 @@ class TestUpgradeImportSystem(unittest.TestCase):
             tmpfile = tempfile.mktemp()
             tmpdir = tempfile.mkdtemp()
             self.assertIn(
-                f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpfile
+                f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+                tmpfile,
             )
             self.assertIn(
-                f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp", tmpdir
+                f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp",
+                tmpdir,
             )
             self.assertFalse(os.path.exists(tmpfile))
             self.assertTrue(os.path.exists(tmpdir))

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,5 +1,6 @@
 from requre.objects import ObjectStorage
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 from tests.testbase import BaseClass
 
 
@@ -39,7 +40,7 @@ class StoreAnyRequest(BaseClass):
         """
         obj_before = ObjectStorage.execute_all_keys(OwnClass, 1)
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         obj_after = ObjectStorage.execute_all_keys(OwnClass, 1)
         self.assertEqual(obj_before.num, obj_after.num)
         # all objects are already read, next have to fail
@@ -52,7 +53,7 @@ class StoreAnyRequest(BaseClass):
         decorated_own = ObjectStorage.decorator_all_keys(OwnClass)
         obj_before = decorated_own(1)
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         obj_after = decorated_own(1)
         self.assertEqual(obj_before.num, obj_after.num)
         # all objects are already read, next have to fail

--- a/tests/test_request_response.py
+++ b/tests/test_request_response.py
@@ -2,6 +2,7 @@ import importlib
 
 from requre.helpers.requests_response import RequestResponseHandling
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 from tests.testbase import BaseClass
 
 
@@ -40,7 +41,7 @@ class StoreAnyRequest(BaseClass):
             self.requests.post, self.domain
         )
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         response_after = RequestResponseHandling.execute_all_keys(
             self.requests.post, self.domain
         )
@@ -61,7 +62,7 @@ class StoreAnyRequest(BaseClass):
         )
         response_before = self.requests.post(self.domain)
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         response_after = self.requests.post(self.domain)
         self.assertEqual(response_before.text, response_after.text)
@@ -75,7 +76,7 @@ class StoreAnyRequest(BaseClass):
             self.requests.post
         )
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         self.assertRaises(Exception, self.requests.post, self.domain, data={"a": "b"})
 
     def testFunctionCustomFields(self):
@@ -91,7 +92,7 @@ class StoreAnyRequest(BaseClass):
             "http://www.google.com", data={"a": "b"}
         )
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         response_after = self.requests.post(self.domain)
         response_google_after = self.requests.post("http://www.google.com")
@@ -109,7 +110,7 @@ class StoreAnyRequest(BaseClass):
         self.requests.post(self.domain, data={"a": "b"})
         response_2 = self.requests.post(self.domain, data={"c": "d"})
         PersistentObjectStorage().dump()
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
 
         self.assertRaises(Exception, self.requests.post, self.domain, data={"x": "y"})
         self.assertRaises(KeyError, self.requests.post, self.domain)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -164,7 +164,7 @@ class Metadata(BaseClass):
 
         PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         self.assertAlmostEqual(
-            0, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
         # Try to set some custom metadata
         DataMiner().data.metadata = {"random": "data"}
@@ -172,31 +172,31 @@ class Metadata(BaseClass):
         time.sleep(0.1)
         PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertAlmostEqual(
-            0.1, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0.1, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
 
         time.sleep(0.2)
         PersistentObjectStorage().store(keys=self.keys, values="z", metadata={})
         self.assertAlmostEqual(
-            0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0.2, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
         self.assertIn(self.keys, PersistentObjectStorage())
         self.assertAlmostEqual(
-            0, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
         # check custom metadata
         self.assertEqual("data", DataMiner().metadata["random"])
 
         self.assertIn(self.keys, PersistentObjectStorage())
         self.assertAlmostEqual(
-            0.1, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0.1, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
         # check if custom metadata are not everywhere
         self.assertNotIn("random", DataMiner().metadata)
         self.assertIn("latency", DataMiner().metadata)
         self.assertIn(self.keys, PersistentObjectStorage())
         self.assertAlmostEqual(
-            0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0.2, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
 
     def test_generic(self):
@@ -277,7 +277,7 @@ class Latency(BaseClass):
         time.sleep(0.2)
         PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertAlmostEqual(
-            0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0.2, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
 
         time_begin = time.time()
@@ -296,7 +296,7 @@ class Latency(BaseClass):
         time.sleep(0.2)
         PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertAlmostEqual(
-            0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
+            0.2, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
 
         time_begin = time.time()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,15 +3,15 @@ import time
 
 from requre.constants import VERSION_REQURE_FILE
 from requre.exceptions import PersistentStorageException
+from requre.helpers.simple_object import Simple
 from requre.storage import (
     DataMiner,
     DataTypes,
     StorageKeysInspectDefault,
     StorageKeysInspectSimple,
     StorageKeysInspect,
+    PersistentObjectStorage,
 )
-from requre.utils import STORAGE
-from requre.helpers.simple_object import Simple
 from tests.testbase import BaseClass
 
 
@@ -20,60 +20,71 @@ class Base(BaseClass):
 
     def setUp(self) -> None:
         super().setUp()
-        STORAGE.dump_after_store = False
+        PersistentObjectStorage().dump_after_store = False
 
     def store_keys_example(self):
-        STORAGE.store(self.keys, values="c", metadata={})
-        STORAGE.store(self.keys, values="d", metadata={})
+        PersistentObjectStorage().store(self.keys, values="c", metadata={})
+        PersistentObjectStorage().store(self.keys, values="d", metadata={})
 
     def test_simple(self):
         self.store_keys_example()
-        self.assertEqual("c", STORAGE.read(self.keys))
-        self.assertEqual("d", STORAGE.read(self.keys))
+        self.assertEqual("c", PersistentObjectStorage().read(self.keys))
+        self.assertEqual("d", PersistentObjectStorage().read(self.keys))
 
     def test_exception(self):
         self.test_simple()
-        self.assertRaises(PersistentStorageException, STORAGE.read, self.keys)
+        self.assertRaises(
+            PersistentStorageException, PersistentObjectStorage().read, self.keys
+        )
 
     def test_write(self):
         self.store_keys_example()
         self.assertFalse(os.path.exists(self.response_file))
-        STORAGE.dump()
+        PersistentObjectStorage().dump()
         self.assertTrue(os.path.exists(self.response_file))
 
 
 class Versioning(BaseClass):
     def setUp(self) -> None:
         super().setUp()
-        STORAGE.dump_after_store = False
+        PersistentObjectStorage().dump_after_store = False
 
     def test_no_version(self):
         """
         Check if storage is able to read and write version to persistent storage file
         """
-        self.assertEqual({}, STORAGE.metadata)
-        self.assertEqual(0, STORAGE.storage_file_version)
-        self.assertEqual(None, STORAGE.metadata.get(STORAGE.version_key))
+        self.assertEqual({}, PersistentObjectStorage().metadata)
+        self.assertEqual(0, PersistentObjectStorage().storage_file_version)
+        self.assertEqual(
+            None,
+            PersistentObjectStorage().metadata.get(
+                PersistentObjectStorage().version_key
+            ),
+        )
         self.assertFalse(os.path.exists(self.response_file))
 
     def test_no_version_after_dump(self):
-        STORAGE.dump()
-        STORAGE.storage_object = {}
-        self.assertEqual({}, STORAGE.metadata)
-        self.assertEqual(0, STORAGE.storage_file_version)
+        PersistentObjectStorage().dump()
+        PersistentObjectStorage().storage_object = {}
+        self.assertEqual({}, PersistentObjectStorage().metadata)
+        self.assertEqual(0, PersistentObjectStorage().storage_file_version)
 
     def test_current_version(self):
-        STORAGE.dump()
+        PersistentObjectStorage().dump()
         self.assertTrue(os.path.exists(self.response_file))
-        self.assertEqual(VERSION_REQURE_FILE, STORAGE.storage_file_version)
-        self.assertNotEqual({}, STORAGE.metadata)
+        self.assertEqual(
+            VERSION_REQURE_FILE, PersistentObjectStorage().storage_file_version
+        )
+        self.assertNotEqual({}, PersistentObjectStorage().metadata)
 
     def test_current_version_after_load(self):
-        STORAGE.dump()
-        STORAGE.load()
-        self.assertEqual(VERSION_REQURE_FILE, STORAGE.storage_file_version)
-        self.assertNotEqual({}, STORAGE.metadata)
-        self.assertIn("version_storage_file", STORAGE.metadata)
+        PersistentObjectStorage().dump()
+        PersistentObjectStorage().load()
+        self.assertEqual(
+            VERSION_REQURE_FILE, PersistentObjectStorage().storage_file_version
+        )
+        self.assertNotEqual({}, PersistentObjectStorage().metadata)
+        self.assertIn("version_storage_file", PersistentObjectStorage().metadata)
 
 
 class TestStoreTypes(BaseClass):
@@ -86,37 +97,37 @@ class TestStoreTypes(BaseClass):
         self.assertEqual(DataTypes.List, DataMiner().data_type)
 
     def test_list_data(self):
-        STORAGE.store(keys=self.keys, values="x", metadata={})
-        STORAGE.store(keys=self.keys, values="y", metadata={})
-        self.assertEqual(2, len(STORAGE.storage_object["a"]["b"]))
-        self.assertEqual("x", STORAGE.read(keys=self.keys))
-        self.assertEqual(1, len(STORAGE.storage_object["a"]["b"]))
-        self.assertEqual("y", STORAGE.read(keys=self.keys))
-        self.assertEqual(0, len(STORAGE.storage_object["a"]["b"]))
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
+        self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
+        self.assertEqual("x", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual(1, len(PersistentObjectStorage().storage_object["a"]["b"]))
+        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual(0, len(PersistentObjectStorage().storage_object["a"]["b"]))
 
     def test_value_data(self):
         DataMiner().data_type = DataTypes.Value
-        STORAGE.store(keys=self.keys, values="x", metadata={})
-        STORAGE.store(keys=self.keys, values="y", metadata={})
-        self.assertEqual(2, len(STORAGE.storage_object["a"]["b"]))
-        self.assertEqual("y", STORAGE.read(keys=self.keys))
-        self.assertEqual(2, len(STORAGE.storage_object["a"]["b"]))
-        self.assertEqual("y", STORAGE.read(keys=self.keys))
-        self.assertEqual(2, len(STORAGE.storage_object["a"]["b"]))
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
+        self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
+        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
+        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
 
     def test_dict_data(self):
         DataMiner().data_type = DataTypes.Dict
         DataMiner().key = "first-key"
-        STORAGE.store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         DataMiner().key = "second-key"
-        STORAGE.store(keys=self.keys, values="y", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
 
-        self.assertIn("first-key", STORAGE.storage_object["a"]["b"])
-        self.assertIn("second-key", STORAGE.storage_object["a"]["b"])
+        self.assertIn("first-key", PersistentObjectStorage().storage_object["a"]["b"])
+        self.assertIn("second-key", PersistentObjectStorage().storage_object["a"]["b"])
 
-        self.assertEqual("y", STORAGE.read(keys=self.keys))
+        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
         DataMiner().key = "first-key"
-        self.assertEqual("x", STORAGE.read(keys=self.keys))
+        self.assertEqual("x", PersistentObjectStorage().read(keys=self.keys))
 
 
 class Metadata(BaseClass):
@@ -134,7 +145,7 @@ class Metadata(BaseClass):
     def test_latency(self):
         delta = 0.05
 
-        STORAGE.store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         self.assertAlmostEqual(
             0, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
@@ -142,25 +153,25 @@ class Metadata(BaseClass):
         DataMiner().data.metadata = {"random": "data"}
 
         time.sleep(0.1)
-        STORAGE.store(keys=self.keys, values="y", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertAlmostEqual(
             0.1, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
 
         time.sleep(0.2)
-        STORAGE.store(keys=self.keys, values="z", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="z", metadata={})
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
 
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         self.assertAlmostEqual(
             0, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
         # check custom metadata
         self.assertEqual("data", DataMiner().metadata["random"])
 
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         self.assertAlmostEqual(
             0.1, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
@@ -168,59 +179,67 @@ class Metadata(BaseClass):
         self.assertNotIn("random", DataMiner().metadata)
         self.assertIn("latency", DataMiner().metadata)
 
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
 
     def test_generic(self):
-        STORAGE.store(keys=self.keys, values="x", metadata={"test_meta": "yes"})
-        STORAGE.metadata = {"rpms": ["package1", "package2"]}
-        STORAGE.dump()
-        STORAGE.storage_object = {}
-        STORAGE.load()
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().store(
+            keys=self.keys, values="x", metadata={"test_meta": "yes"}
+        )
+        PersistentObjectStorage().metadata = {"rpms": ["package1", "package2"]}
+        PersistentObjectStorage().dump()
+        PersistentObjectStorage().storage_object = {}
+        PersistentObjectStorage().load()
+        PersistentObjectStorage().read(keys=self.keys)
         self.assertEqual(DataMiner().metadata["test_meta"], "yes")
         self.assertEqual(
-            STORAGE.metadata.get(STORAGE.key_inspect_strategy_key),
+            PersistentObjectStorage().metadata.get(
+                PersistentObjectStorage().key_inspect_strategy_key
+            ),
             StorageKeysInspectDefault.__name__,
         )
-        self.assertEqual(STORAGE.metadata.get("rpms"), ["package1", "package2"])
+        self.assertEqual(
+            PersistentObjectStorage().metadata.get("rpms"), ["package1", "package2"]
+        )
 
     def test_strategy(self):
         DataMiner().key_stategy_cls = StorageKeysInspectSimple
-        STORAGE.store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         self.simple_return("ahoj")
         self.simple_return([1, 2, 3])
 
-        STORAGE.dump()
-        STORAGE.storage_object = {}
+        PersistentObjectStorage().dump()
+        PersistentObjectStorage().storage_object = {}
         DataMiner().key_stategy_cls = StorageKeysInspectDefault
-        STORAGE._is_write_mode = False
-        STORAGE.load()
-        self.assertEqual("x", STORAGE.read(keys=self.keys))
+        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().load()
+        self.assertEqual("x", PersistentObjectStorage().read(keys=self.keys))
         self.assertEqual(
-            STORAGE.metadata.get(STORAGE.key_inspect_strategy_key),
+            PersistentObjectStorage().metadata.get(
+                PersistentObjectStorage().key_inspect_strategy_key
+            ),
             StorageKeysInspectSimple.__name__,
         )
         self.assertEqual(StorageKeysInspectSimple, DataMiner().key_stategy_cls)
 
     def test_strategy_proper(self):
         self.test_strategy()
-        STORAGE.load()
-        print(STORAGE.storage_object)
+        PersistentObjectStorage().load()
+        print(PersistentObjectStorage().storage_object)
         self.assertEqual("ahoj", self.simple_return("nonsense"))
         self.assertEqual([1, 2, 3], self.simple_return("nonsense"))
 
     def test_strategy_API_cls(self):
         self.test_strategy()
-        STORAGE.load()
+        PersistentObjectStorage().load()
         DataMiner().key_stategy_cls = StorageKeysInspect
         self.assertRaises(NotImplementedError, self.simple_return, "nonsense")
 
     def test_strategy_default_cls(self):
         self.test_strategy()
-        STORAGE.load()
+        PersistentObjectStorage().load()
         DataMiner().key_stategy_cls = StorageKeysInspectDefault
         self.assertRaises(PersistentStorageException, self.simple_return, "nonsense")
 
@@ -239,38 +258,38 @@ class Latency(BaseClass):
     def test_not_applied(self):
         DataMiner().use_latency = False
         delta = 0.05
-        STORAGE.store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         time.sleep(0.2)
-        STORAGE.store(keys=self.keys, values="y", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
 
         time_begin = time.time()
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
         time_begin = time.time()
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
     def test_applied(self):
         delta = 0.05
-        STORAGE.store(keys=self.keys, values="x", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         time.sleep(0.2)
-        STORAGE.store(keys=self.keys, values="y", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
 
         time_begin = time.time()
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
         time_begin = time.time()
-        STORAGE.read(keys=self.keys)
+        PersistentObjectStorage().read(keys=self.keys)
         time_end = time.time()
         self.assertAlmostEqual(0.2, time_end - time_begin, delta=delta)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -180,21 +180,21 @@ class Metadata(BaseClass):
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
-        self.assertIn(self.keys, PersistentObjectStorage())
+        PersistentObjectStorage().read(self.keys)
         self.assertAlmostEqual(
             0, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
         # check custom metadata
         self.assertEqual("data", DataMiner().metadata["random"])
 
-        self.assertIn(self.keys, PersistentObjectStorage())
+        PersistentObjectStorage().read(self.keys)
         self.assertAlmostEqual(
             0.1, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
         # check if custom metadata are not everywhere
         self.assertNotIn("random", DataMiner().metadata)
         self.assertIn("latency", DataMiner().metadata)
-        self.assertIn(self.keys, PersistentObjectStorage())
+        PersistentObjectStorage().read(self.keys)
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner().LATENCY_KEY], delta=delta
         )
@@ -300,11 +300,11 @@ class Latency(BaseClass):
         )
 
         time_begin = time.time()
-        self.assertIn(self.keys, PersistentObjectStorage())
+        PersistentObjectStorage().read(self.keys)
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
         time_begin = time.time()
-        self.assertIn(self.keys, PersistentObjectStorage())
+        PersistentObjectStorage().read(self.keys)
         time_end = time.time()
         self.assertAlmostEqual(0.2, time_end - time_begin, delta=delta)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -130,6 +130,22 @@ class TestStoreTypes(BaseClass):
         DataMiner().key = "first-key"
         self.assertEqual("x", PersistentObjectStorage()[self.keys])
 
+    def test_dict_with_list_data(self):
+        DataMiner().data_type = DataTypes.DictWithList
+        DataMiner().key = "first-key"
+        PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
+        DataMiner().key = "second-key"
+        PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
+        PersistentObjectStorage().store(keys=self.keys, values="z", metadata={})
+
+        self.assertIn("first-key", PersistentObjectStorage().storage_object["a"]["b"])
+        self.assertIn("second-key", PersistentObjectStorage().storage_object["a"]["b"])
+
+        self.assertEqual("y", PersistentObjectStorage()[self.keys])
+        self.assertEqual("z", PersistentObjectStorage()[self.keys])
+        DataMiner().key = "first-key"
+        self.assertEqual("x", PersistentObjectStorage()[self.keys])
+
 
 class Metadata(BaseClass):
     keys = ["a", "b"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,6 +12,7 @@ from requre.storage import (
     StorageKeysInspect,
     PersistentObjectStorage,
 )
+from requre.utils import StorageMode
 from tests.testbase import BaseClass
 
 
@@ -211,7 +212,7 @@ class Metadata(BaseClass):
         PersistentObjectStorage().dump()
         PersistentObjectStorage().storage_object = {}
         DataMiner().key_stategy_cls = StorageKeysInspectDefault
-        PersistentObjectStorage()._is_write_mode = False
+        PersistentObjectStorage().mode = StorageMode.read
         PersistentObjectStorage().load()
         self.assertEqual("x", PersistentObjectStorage()[self.keys])
         self.assertEqual(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -28,8 +28,8 @@ class Base(BaseClass):
 
     def test_simple(self):
         self.store_keys_example()
-        self.assertEqual("c", PersistentObjectStorage().read(self.keys))
-        self.assertEqual("d", PersistentObjectStorage().read(self.keys))
+        self.assertEqual("c", PersistentObjectStorage()[self.keys])
+        self.assertEqual("d", PersistentObjectStorage()[self.keys])
 
     def test_exception(self):
         self.test_simple()
@@ -100,9 +100,9 @@ class TestStoreTypes(BaseClass):
         PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
-        self.assertEqual("x", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("x", PersistentObjectStorage()[self.keys])
         self.assertEqual(1, len(PersistentObjectStorage().storage_object["a"]["b"]))
-        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("y", PersistentObjectStorage()[self.keys])
         self.assertEqual(0, len(PersistentObjectStorage().storage_object["a"]["b"]))
 
     def test_value_data(self):
@@ -110,9 +110,9 @@ class TestStoreTypes(BaseClass):
         PersistentObjectStorage().store(keys=self.keys, values="x", metadata={})
         PersistentObjectStorage().store(keys=self.keys, values="y", metadata={})
         self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
-        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("y", PersistentObjectStorage()[self.keys])
         self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
-        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("y", PersistentObjectStorage()[self.keys])
         self.assertEqual(2, len(PersistentObjectStorage().storage_object["a"]["b"]))
 
     def test_dict_data(self):
@@ -125,9 +125,9 @@ class TestStoreTypes(BaseClass):
         self.assertIn("first-key", PersistentObjectStorage().storage_object["a"]["b"])
         self.assertIn("second-key", PersistentObjectStorage().storage_object["a"]["b"])
 
-        self.assertEqual("y", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("y", PersistentObjectStorage()[self.keys])
         DataMiner().key = "first-key"
-        self.assertEqual("x", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("x", PersistentObjectStorage()[self.keys])
 
 
 class Metadata(BaseClass):
@@ -163,23 +163,21 @@ class Metadata(BaseClass):
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
-
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         self.assertAlmostEqual(
             0, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
         # check custom metadata
         self.assertEqual("data", DataMiner().metadata["random"])
 
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         self.assertAlmostEqual(
             0.1, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
         # check if custom metadata are not everywhere
         self.assertNotIn("random", DataMiner().metadata)
         self.assertIn("latency", DataMiner().metadata)
-
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         self.assertAlmostEqual(
             0.2, DataMiner().metadata[DataMiner.LATENCY_KEY], delta=delta
         )
@@ -192,7 +190,7 @@ class Metadata(BaseClass):
         PersistentObjectStorage().dump()
         PersistentObjectStorage().storage_object = {}
         PersistentObjectStorage().load()
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         self.assertEqual(DataMiner().metadata["test_meta"], "yes")
         self.assertEqual(
             PersistentObjectStorage().metadata.get(
@@ -215,7 +213,7 @@ class Metadata(BaseClass):
         DataMiner().key_stategy_cls = StorageKeysInspectDefault
         PersistentObjectStorage()._is_write_mode = False
         PersistentObjectStorage().load()
-        self.assertEqual("x", PersistentObjectStorage().read(keys=self.keys))
+        self.assertEqual("x", PersistentObjectStorage()[self.keys])
         self.assertEqual(
             PersistentObjectStorage().metadata.get(
                 PersistentObjectStorage().key_inspect_strategy_key
@@ -266,12 +264,12 @@ class Latency(BaseClass):
         )
 
         time_begin = time.time()
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
         time_begin = time.time()
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
@@ -285,11 +283,11 @@ class Latency(BaseClass):
         )
 
         time_begin = time.time()
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         time_end = time.time()
         self.assertAlmostEqual(0, time_end - time_begin, delta=delta)
 
         time_begin = time.time()
-        PersistentObjectStorage().read(keys=self.keys)
+        self.assertIn(self.keys, PersistentObjectStorage())
         time_end = time.time()
         self.assertAlmostEqual(0.2, time_end - time_begin, delta=delta)

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -1,6 +1,7 @@
 import os
-from requre.utils import STORAGE
+
 from requre.helpers.tempfile import TempFile
+from requre.storage import PersistentObjectStorage
 from tests.testbase import BaseClass
 
 
@@ -8,27 +9,32 @@ class TestTempFile(BaseClass):
     def testSimple(self):
         output = TempFile.mktemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp_1", output
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp_1",
+            output,
         )
 
     def testChangeFile(self):
-        STORAGE.storage_file += ".x"
+        PersistentObjectStorage().storage_file += ".x"
         output = TempFile.mktemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp_1", output
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp_1",
+            output,
         )
         output = TempFile.mktemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp_2", output
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp_2",
+            output,
         )
-        STORAGE.storage_file += ".y"
+        PersistentObjectStorage().storage_file += ".y"
         self.assertEqual(TempFile.counter, 2)
         output = TempFile.mktemp()
         self.assertEqual(TempFile.counter, 1)
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp_1", output
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp_1",
+            output,
         )
         output = TempFile.mktemp()
         self.assertIn(
-            f"/tmp/{os.path.basename(STORAGE.storage_file)}/static_tmp_2", output
+            f"/tmp/{os.path.basename(PersistentObjectStorage().storage_file)}/static_tmp_2",
+            output,
         )

--- a/tests/testbase.py
+++ b/tests/testbase.py
@@ -9,6 +9,7 @@ from requre.utils import StorageMode
 
 class BaseClass(unittest.TestCase):
     def setUp(self) -> None:
+        PersistentObjectStorage().mode = StorageMode.default
         super().setUp()
         self.file_name = None
         self.temp_dir = None
@@ -17,10 +18,8 @@ class BaseClass(unittest.TestCase):
         self.response_file = os.path.join(self.response_dir, "storage_test.yaml")
         PersistentObjectStorage().storage_file = self.response_file
         PersistentObjectStorage().dump_after_store = True
-        PersistentObjectStorage().mode = StorageMode.write
 
     def tearDown(self) -> None:
-        pass
         super().tearDown()
         shutil.rmtree(self.response_dir)
         if self.file_name:

--- a/tests/testbase.py
+++ b/tests/testbase.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 
 
 class BaseClass(unittest.TestCase):
@@ -16,7 +17,7 @@ class BaseClass(unittest.TestCase):
         self.response_file = os.path.join(self.response_dir, "storage_test.yaml")
         PersistentObjectStorage().storage_file = self.response_file
         PersistentObjectStorage().dump_after_store = True
-        PersistentObjectStorage()._is_write_mode = True
+        PersistentObjectStorage().mode = StorageMode.write
 
     def tearDown(self) -> None:
         pass


### PR DESCRIPTION
- Three modes: `read`, `write` and `readwrite` (=append).
- `PersistentObjectStorage` implements the dict-like methods:
    - `["some", "keys"] in PersistentObjectStorage()`
     - `PersistentObjectStorage()[keys]`
- Added `DictWithList` type.
- Removed `STORAGE` (problems with the imports).