### PR TITLE
record git fetch info objects for fetch operation

### DIFF
--- a/requre/helpers/files.py
+++ b/requre/helpers/files.py
@@ -93,7 +93,12 @@ class StoreFiles:
                                 tar_item.name = tar_item.name.split(os.path.sep, 1)[1]
                             else:
                                 tar_item.name = "."
-                            tar_store.extract(tar_item, path=pathname)
+                            try:
+                                tar_store.extract(tar_item, path=pathname)
+                            except IOError:
+                                # rewrite readonly files if necessary
+                                os.remove(os.path.join(pathname, tar_item.name))
+                                tar_store.extract(tar_item, path=pathname)
 
     @classmethod
     def return_value(cls, func: Callable) -> Any:
@@ -183,3 +188,15 @@ class StoreFiles:
             return store_files_int_int
 
         return store_files_int
+
+    @classmethod
+    def explicit_reference(cls, file_param: str, dest_key: str = "default") -> Any:
+        """
+        Method to store explicitly path file_param to persistent storage
+        """
+        class_test_id_list = [cls.__name__, cls._test_identifier()]
+        cls._copy_logic(
+            PersistentObjectStorage(),
+            pathname=file_param,
+            keys=class_test_id_list + [dest_key],
+        )

--- a/requre/helpers/git/fetchinfo.py
+++ b/requre/helpers/git/fetchinfo.py
@@ -1,0 +1,88 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from typing import Any, Callable, List
+
+from git.remote import FetchInfo
+from git.util import IterableList
+from requre.storage import PersistentObjectStorage
+from requre.objects import ObjectStorage
+from requre.helpers.files import StoreFiles
+
+
+class FetchInfoStorageList(ObjectStorage):
+    # TODO: improve handling of "ref" item (need deep inspection of git objects and consequences)
+    # it is not mandatory for current packit operations
+    __ignored = ["ref"]
+    __response_keys_special: List[str] = []
+    __response_keys = list(
+        set(FetchInfo.__slots__) - set(__ignored) - set(__response_keys_special)
+    )
+
+    object_type = IterableList
+
+    def to_serializable(self, obj: Any) -> Any:
+        output = list()
+        for item in obj:
+            tmp = dict()
+            for key in self.__response_keys:
+                tmp[key] = getattr(item, key)
+            output.append(tmp)
+        return output
+
+    def from_serializable(self, data: Any) -> Any:
+        out = self.object_type("name")
+        for item in data:
+            tmp = FetchInfo(None, None, None, None)
+            for key in self.__response_keys:
+                setattr(tmp, key, item[key])
+            out.append(tmp)
+        return out
+
+
+class RemoteFetch(FetchInfoStorageList):
+    """
+    Use this class for git.remote.Remote.fetch recording
+    """
+
+    @classmethod
+    def execute(cls, keys: list, func: Callable, *args, **kwargs) -> Any:
+        """
+        Class method to store or read object from persistent storage
+        with explicit set of *args, **kwargs parameters to use as keys
+        :param keys: list of keys used as parameter
+        :param func: original function
+        :param args: parameters of original function
+        :param kwargs: parameters of original function
+        :return: output of called func
+        """
+
+        super().execute(keys, func, *args, **kwargs)
+        git_object = args[0]
+        git_dir = git_object.repo.git_dir
+        StoreFiles.explicit_reference(git_dir)
+        if not PersistentObjectStorage().do_store(keys):
+            # mimic the code in git for read mode for Remote.fetch
+            # https://github.com/gitpython-developers/GitPython/blob/master/git/remote.py
+            if hasattr(git_object.repo.odb, "update_cache"):
+                git_object.repo.odb.update_cache()

--- a/requre/helpers/git/fetchinfo.py
+++ b/requre/helpers/git/fetchinfo.py
@@ -77,7 +77,7 @@ class RemoteFetch(FetchInfoStorageList):
         :return: output of called func
         """
 
-        super().execute(keys, func, *args, **kwargs)
+        output = super().execute(keys, func, *args, **kwargs)
         git_object = args[0]
         git_dir = git_object.repo.git_dir
         StoreFiles.explicit_reference(git_dir)
@@ -86,3 +86,4 @@ class RemoteFetch(FetchInfoStorageList):
             # https://github.com/gitpython-developers/GitPython/blob/master/git/remote.py
             if hasattr(git_object.repo.odb, "update_cache"):
                 git_object.repo.odb.update_cache()
+        return output

--- a/requre/helpers/git/pushinfo.py
+++ b/requre/helpers/git/pushinfo.py
@@ -81,8 +81,9 @@ class PushInfoStorageList(ObjectStorage):
         :return: output of called func
         """
 
-        super().execute(keys, func, *args, **kwargs)
+        output = super().execute(keys, func, *args, **kwargs)
         git_object = args[0]
         remote_url = git_object.repo.remotes[git_object.name].url
         if os.path.isdir(remote_url):
             StoreFiles.explicit_reference(remote_url)
+        return output

--- a/requre/helpers/git/pushinfo.py
+++ b/requre/helpers/git/pushinfo.py
@@ -21,7 +21,8 @@
 # SOFTWARE.
 
 
-from typing import Any
+import os
+from typing import Any, Callable
 
 from git.refs.head import HEAD
 from git.remote import PushInfo
@@ -29,6 +30,7 @@ from git.repo.base import Repo
 from git.util import IterableList
 
 from requre.objects import ObjectStorage
+from requre.helpers.files import StoreFiles
 
 
 class PushInfoStorageList(ObjectStorage):
@@ -66,3 +68,21 @@ class PushInfoStorageList(ObjectStorage):
                     setattr(tmp, key, HEAD(Repo(item[key][0])))
             out.append(tmp)
         return out
+
+    @classmethod
+    def execute(cls, keys: list, func: Callable, *args, **kwargs) -> Any:
+        """
+        Class method to store or read object from persistent storage
+        with explicit set of *args, **kwargs parameters to use as keys
+        :param keys: list of keys used as parameter
+        :param func: original function
+        :param args: parameters of original function
+        :param kwargs: parameters of original function
+        :return: output of called func
+        """
+
+        super().execute(keys, func, *args, **kwargs)
+        git_object = args[0]
+        remote_url = git_object.repo.remotes[git_object.name].url
+        if os.path.isdir(remote_url):
+            StoreFiles.explicit_reference(remote_url)


### PR DESCRIPTION
Use it in packit to solve git fetch issue in zuul:
```
    .decorate(
        where="git",
        who_name="local_project",
        what="remote.Remote.fetch",
        decorator=RemoteFetch.decorator_plain,
    )
```
This should work also for ``remote.Remote.pull`` because output and function is more less same. decorate also ``pull`` if you want.