### PR TITLE
Stop building wheel from Git checkout in CI/CD

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
         # https://pypa-build.readthedocs.io
         run: |
           python -m pip install build
-          python -m build --sdist --wheel
+          python -m build
 
       - name: Publish 📦 to PyPI
         # https://github.com/pypa/gh-action-pypi-publish


### PR DESCRIPTION
When python -m build is invoked with --sdist and/or --wheel args, both artifacts get created from source. This is bad because it differs from what pip does when it needs to build a package from the source distribution before installation.

See also: packit/packit#1734, packit/ogr#778