### PR TITLE
Bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -59,6 +59,6 @@ jobs:
 
       - name: Publish 📦 to PyPI
         # https://github.com/pypa/gh-action-pypi-publish
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           verbose: true


### PR DESCRIPTION
Related to: [#2756](https://github.com/packit/packit/issues/2756)
