### PR TITLE
Bump tmt version in pre-commit to v1.66.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
           - --comment-style
           - "#"
   - repo: https://github.com/teemtee/tmt.git
-    rev: 1.41.0
+    rev: 1.66.0
     hooks:
       - id: tmt-lint
         # Do not run in pre-commit.ci as it requires an internet access


### PR DESCRIPTION
This fixes the following pre-commit fail in CI:

```
tmt lint.................................................................Failed
- hook id: tmt-lint
- duration: 3.58s
- exit code: 2

The 'test' attribute in '/tests/full' must be defined.

The 'test' attribute in '/tests/smoke/importing' must be defined.
```

This bump was [done in the `packit` repo in the past](https://github.com/packit/packit/commit/b400bdbb18facd1922c4b117bff8737d54e3c17f) for the same reason.